### PR TITLE
External SBOMs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
     secrets:
       token:
         required: true
+        description: GitHub token
 
 permissions:
   contents: read
@@ -29,6 +30,10 @@ jobs:
       - name: "🌎 Setup Cosign"
         uses: sigstore/cosign-installer@7e0881f8fe90b25e305bbf0309761e9314607e25 # tag=v2.4.0
 
+      - name: "🕵️ Extract git tree"
+        run: echo ::set-output name=tree::$(git log --pretty='%T' -1)
+        id: git-data
+
       - name: "🐳 Logging in to Docker Registry"
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # tag=v2.0.0
         with:
@@ -36,15 +41,15 @@ jobs:
           username: ${{github.repository_owner}}
           password: ${{secrets.token}}
       - name: "🚧 Building image"
-        run: docker build -t ghcr.io/${{github.repository}}:${{github.sha}} .
+        run: docker build -t ghcr.io/${{github.repository}}:${{steps.git-data.outputs.tree}} .
       - name: "📸 Generate SBOM"
-        run: syft packages -o cyclonedx-json=sbom.cyclonedx.json ghcr.io/${{github.repository}}:${{github.sha}}
+        run: syft packages -o cyclonedx-json=sbom.cyclonedx.json ghcr.io/${{github.repository}}:${{steps.git-data.outputs.tree}}
 
       - name: "📦 Pushing image"
-        run: docker push ghcr.io/${{github.repository}}:${{github.sha}}
+        run: docker push ghcr.io/${{github.repository}}:${{steps.git-data.outputs.tree}}
       - name: "🔏 Pushing SBOM"
         run: |
-          cosign attest --force --predicate sbom.cyclonedx.json ghcr.io/${{github.repository}}:${{github.sha}}
+          cosign attest --force --predicate sbom.cyclonedx.json ghcr.io/${{github.repository}}:${{steps.git-data.outputs.tree}}
 
       # TODO: pin after dev
       - name: "📢 Post SBOM Diff"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,29 +1,19 @@
 name: Build
 on:
   workflow_call:
-    inputs:
-      committer:
-        required: false
-        type: string
-        description: The committer name
-        default: "wapwagner" # wapwagner number one
-      committer_email:
-        required: false
-        type: string
-        description: The committer email
-        default: "70587923+wapwagner@users.noreply.github.com"
     secrets:
-      not_github_token:
+      token:
         required: true
-        description: A non-Actions GitHub token, so Actions will react to pushes.
 
 permissions:
-  contents: write 
-  actions: write
+  contents: read
+  packages: write
   pull-requests: write
-  
+  id-token: write
+
 env:
   DOCKER_BUILDKIT: 1
+  COSIGN_EXPERIMENTAL: true
 
 jobs:
   build:
@@ -34,69 +24,31 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: "🌎 Logging in to Docker Registry"
+      - name: "🌎 Setup Syft"
+        uses: anchore/sbom-action/download-syft@bb716408e75840bbb01e839347cd213767269d4a # tag=v0.11.0
+      - name: "🌎 Setup Cosign"
+        uses: sigstore/cosign-installer@7e0881f8fe90b25e305bbf0309761e9314607e25 # tag=v2.4.0
+
+      - name: "🐳 Logging in to Docker Registry"
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # tag=v2.0.0
         with:
           registry: ghcr.io
           username: ${{github.repository_owner}}
-          password: ${{secrets.not_github_token}}
-
+          password: ${{secrets.token}}
       - name: "🚧 Building image"
-        run: docker build --secret id=git-credentials,env=GITHUB_TOKEN -t ghcr.io/${{github.repository}}:${{github.sha}} .
-        env:
-          GITHUB_TOKEN: ${{secrets.not_github_token}}
-
-      - name: "📷 Setup Syft"
-        uses: anchore/sbom-action/download-syft@bb716408e75840bbb01e839347cd213767269d4a # tag=v0.11.0
+        run: docker build -t ghcr.io/${{github.repository}}:${{github.sha}} .
       - name: "📸 Generate SBOM"
         run: syft packages -o cyclonedx-json=sbom.cyclonedx.json ghcr.io/${{github.repository}}:${{github.sha}}
 
-      - name: "🕵️ Verify SBOM"
-        id: verify
+      - name: "📦 Pushing image"
+        run: docker push ghcr.io/${{github.repository}}:${{github.sha}}
+      - name: "🔏 Pushing SBOM"
         run: |
-          BUILT_PACKAGES=$(jq -r '.components[].purl' sbom.cyclonedx.json | grep -v ^null | sort)
-          if [[ -f go.mod ]]; then
-            OWN_MODULE=$(grep ^module go.mod | cut -d' ' -f2)
-            BUILT_PACKAGES=$(echo -e "$BUILT_PACKAGES" | grep -v "$OWN_MODULE")
-          fi
-          echo "Built packages:"
-          echo "$BUILT_PACKAGES" | tee built.txt
-          echo ""
-          echo ""
-          echo ""
+          cosign attest --force --predicate sbom.cyclonedx.json ghcr.io/${{github.repository}}:${{github.sha}}
 
-          STORED_PACKAGES=$(jq -r '.components[].purl' Dockerfile.cyclonedx.json | grep -v ^null | sort)
-          if [[ -f go.mod ]]; then
-            OWN_MODULE=$(grep ^module go.mod | cut -d' ' -f2)
-            STORED_PACKAGES=$(echo -e "$STORED_PACKAGES" | grep -v "$OWN_MODULE")
-          fi
-          echo "Stored packages:"
-          echo "$STORED_PACKAGES" | tee stored.txt
-
-          # Exit if packages match the committed SBOM
-          (diff -b -U 0 stored.txt built.txt || true) > pkgdiff.txt
-          if [[ ! -s pkgdiff.txt ]]; then
-            exit 0
-          fi
-
-          # On mismatch, commit and push the updated SBOM:
-          git reset origin/${GITHUB_HEAD_REF}
-          mv sbom.cyclonedx.json Dockerfile.cyclonedx.json
-          git config user.name "${{inputs.committer}}"
-          git config user.email "${{inputs.committer_email}}"
-          git add Dockerfile.cyclonedx.json
-          git commit -m'generated SBOM'
-          git push "https://${{inputs.committer}}:${{secrets.not_github_token}}@github.com/${GITHUB_REPOSITORY}.git" HEAD:${GITHUB_HEAD_REF}
-          exit 1
-      - name: "🔊 Comment on PR"
-        uses: actions/github-script@7a5c598405937d486b0331594b5da2b14db670da # tag=v6.1.0
-        if: ${{ failure() && steps.verify.outcome == 'failure'}}
+      # TODO: pin after dev
+      - name: "📢 Post SBOM Diff"
+        uses: thepwagner/sbom-action@main
         with:
-          script: |
-            const fs = require('fs');
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '```\n' + fs.readFileSync('pkgdiff.txt') + '\n```',
-            });
+          sbom: sbom.cyclonedx.json
+          base-image: ghcr.io/${{github.repository}}:latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,5 +38,12 @@ jobs:
           username: ${{github.repository_owner}}
           password: ${{secrets.token}}
 
-      - name: "🚧 Pulling image"
+      - name: "👇 Pulling image"
         run: docker pull ghcr.io/${{github.repository}}:${{steps.git-data.outputs.tree}}
+      - name: "👆 Pushing image"
+        run: |
+          docker tag ghcr.io/${{github.repository}}:${{steps.git-data.outputs.tree}} ghcr.io/${{github.repository}}:latest
+          docker push ghcr.io/${{github.repository}}:latest
+      - name: "🔏 Signing image"
+        run: |
+          cosign sign --force ghcr.io/${{github.repository}}:latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,10 +8,12 @@ on:
 
 permissions:
   contents: read
-  actions: read
-  
+  packages: write
+  id-token: write
+
 env:
   DOCKER_BUILDKIT: 1
+  COSIGN_EXPERIMENTAL: true
 
 jobs:
   publish:
@@ -22,47 +24,19 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
         with:
           persist-credentials: false
-      - name: "🌎 Logging in to Docker Registry"
+      - name: "🌎 Setup Cosign"
+        uses: sigstore/cosign-installer@7e0881f8fe90b25e305bbf0309761e9314607e25 # tag=v2.4.0
+
+      - name: "🕵️ Extract git tree"
+        run: echo ::set-output name=tree::$(git log --pretty='%T' -1)
+        id: git-data
+
+      - name: "🐳 Logging in to Docker Registry"
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # tag=v2.0.0
         with:
           registry: ghcr.io
           username: ${{github.repository_owner}}
           password: ${{secrets.token}}
 
-      - name: "🚧 Building image"
-        run: docker build --secret id=git-credentials,env=GITHUB_TOKEN -t ghcr.io/${{github.repository}}:${{github.sha}} .
-        env:
-          GITHUB_TOKEN: ${{secrets.token}}
-
-      - name: "📷 Setup Syft"
-        uses: anchore/sbom-action/download-syft@bb716408e75840bbb01e839347cd213767269d4a # tag=v0.11.0
-      - name: "📸 Generate SBOM"
-        run: syft packages -o cyclonedx-json=sbom.cyclonedx.json ghcr.io/${{github.repository}}:${{github.sha}}
-
-      - name: "🕵️ Verify SBOM"
-        run: |
-          # Exit if packages match the committed SBOM
-          BUILT_PACKAGES=$(jq -r '.components[].purl' sbom.cyclonedx.json | grep -v ^null | sort)
-          if [[ -f go.mod ]]; then
-            OWN_MODULE=$(grep ^module go.mod | cut -d' ' -f2)
-            BUILT_PACKAGES=$(echo -e "$BUILT_PACKAGES" | grep -v "$OWN_MODULE")
-          fi
-          echo "Built packages:"
-          echo "$BUILT_PACKAGES" | tee built.txt
-          echo ""
-          echo ""
-          echo ""
-
-          STORED_PACKAGES=$(jq -r '.components[].purl' Dockerfile.cyclonedx.json | grep -v ^null | sort)
-          if [[ -f go.mod ]]; then
-            OWN_MODULE=$(grep ^module go.mod | cut -d' ' -f2)
-            STORED_PACKAGES=$(echo -e "$STORED_PACKAGES" | grep -v "$OWN_MODULE")
-          fi
-          echo "Stored packages:"
-          echo "$STORED_PACKAGES" | tee stored.txt
-
-          (diff -b -U 0 stored.txt built.txt || true) > pkgdiff.txt
-          [[ -s pkgdiff.txt ]] && exit 1
-
-          docker tag ghcr.io/${{github.repository}}:${{github.sha}} ghcr.io/${{github.repository}}:latest
-          docker push ghcr.io/${{github.repository}}:latest
+      - name: "🚧 Pulling image"
+        run: docker pull ghcr.io/${{github.repository}}:${{steps.git-data.outputs.tree}}


### PR DESCRIPTION
Previously I'd store an SBOM within the host repository. This is the cheapest solution, but having the file (and history) in git is less useful than I thought it would be.

Since everything lives in Actions, using https://github.com/sigstore/cosign 's `attach-attestation` is a cool alternative: I avoid `contents:write` permission and requiring personal access tokens. I avoid the potential to infinitely loop actions.

This promotes the SBOM diff functionality from a shell script to a standalone action in https://github.com/thepwagner/sbom-action .