### PR TITLE
attest-build-provenance

### DIFF
--- a/.github/workflows/golang-release-attest.yaml
+++ b/.github/workflows/golang-release-attest.yaml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # to attach artifacts to releases
+      id-token: write
+      attestations: write
     steps:
       - name: "🌎 Fetching code"
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -48,3 +50,11 @@ jobs:
           args: release --clean --parallelism=1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "🔏 Sign .deb"
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+        with:
+          subject-path: "dist/*.deb"
+      - name: "🔏 Sign .tar.gz"
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+        with:
+          subject-path: "dist/*.tar.gz"

--- a/.github/workflows/golang-release.yaml
+++ b/.github/workflows/golang-release.yaml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # to attach artifacts to releases
+      id-token: write
+      attestations: write
     steps:
       - name: "🌎 Fetching code"
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -44,7 +46,15 @@ jobs:
       - name: "📦 Release"
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # tag=v5.0.0
         with:
-          version: v1.22.1
+          version: v1.25.1
           args: release --clean --parallelism=1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "🔏 Sign .deb"
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+        with:
+          subject-path: "dist/*.deb"
+      - name: "🔏 Sign .tar.gz"
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+        with:
+          subject-path: "dist/*.tar.gz"


### PR DESCRIPTION
Sign tarball and deb with the new GitHub feature.

I didn't sign my private builds before, now I can. Neat.