### PR TITLE
golang-test: optional deb-packages input

### DIFF
--- a/.github/workflows/golang-test.yaml
+++ b/.github/workflows/golang-test.yaml
@@ -8,6 +8,11 @@ on:
         type: string
         description: Path to go.mod file
         default: "go.mod"
+      deb-packages:
+        required: false
+        type: string
+        description: Comma-separated list of debian packages to install
+        default: ""
 
 permissions: {}
 
@@ -18,15 +23,32 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout
+      - name: "🌎 Fetching code"
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
-      - name: Set up Go
+      - name: "👷 Setup Go"
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: ${{inputs.go-version-file}}
-      - run: go test -v -coverprofile=coverage.out -race ./...
-      - run: go tool cover -html=coverage.out -o=coverage.html
-      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      - name: "🐧 Install deb dependencies"
+        if: ${{inputs.deb-packages != ''}}
+        env:
+          DEB_PACKAGES: ${{inputs.deb-packages}}
+        run: |
+          ALLOWLIST='^(libsodium-dev|curl)$'
+
+          IFS=',' read -ra packages <<< "$DEB_PACKAGES"
+          for pkg in "${packages[@]}"; do
+            echo "$pkg" | grep -Eq "$ALLOWLIST" || exit 1
+            sudo apt-get install -y --no-install-recommends -- "$pkg"
+          done
+
+      - name: "🧪 Test"
+        run: |
+          go test -v -coverprofile=coverage.out -race ./...
+          go tool cover -html=coverage.out -o=coverage.html
+
+      - name: "💾 Upload coverage"
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: code-coverage-report
           path: coverage.html
@@ -38,13 +60,28 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout
+      - name: "🌎 Fetching code"
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
-      - name: Set up Go
+      - name: "👷 Setup Go"
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: ${{inputs.go-version-file}}
-      - run: curl -o .golangci.yml -sSfL https://raw.githubusercontent.com/thepwagner-org/golangci-lint/main/.golangci.yml
-      - uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
+      - name: "🐧 Install deb dependencies"
+        if: ${{inputs.deb-packages != ''}}
+        env:
+          DEB_PACKAGES: ${{inputs.deb-packages}}
+        run: |
+          ALLOWLIST='^(libsodium-dev|curl)$'
+
+          IFS=',' read -ra packages <<< "$DEB_PACKAGES"
+          for pkg in "${packages[@]}"; do
+            echo "$pkg" | grep -Eq "$ALLOWLIST" || exit 1
+            sudo apt-get install -y --no-install-recommends -- "$pkg"
+          done
+
+      - name: "🌎 Fetching linter configuration"
+        run: curl -o .golangci.yml -sSfL https://raw.githubusercontent.com/thepwagner-org/golangci-lint/main/.golangci.yml
+      - name: "🚓 Lint"
+        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
           args: --timeout=30m


### PR DESCRIPTION
Allow callers of `golang-test` to specify debian dependencies.

Specifically I want `libsodium-dev`, so that https://github.com/thepwagner/actions-templates can encrypt Actions secrets.